### PR TITLE
Use 'clap' to parse arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,11 +51,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "cli"
 version = "0.1.0"
 dependencies = [
  "boucle",
+ "clap",
  "hound",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -77,6 +122,33 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vst"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 
 [dependencies]
 boucle = { path = "../boucle" }
+clap = "2"
 hound = "3.4.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,39 +3,18 @@ use boucle::op_sequence;
 use boucle::Sample;
 use boucle::OpSequence;
 
+use clap::{Arg, App};
 use hound;
 
-use std::env;
 use std::fs::File;
 use std::io;
 use std::io::Read;
 use std::io::Write;
 
-fn parse_args(args: &[String]) -> Result<(Box<dyn Read>, Box<dyn Read>, Box<dyn Write>), io::Error> {
-    let operations = Box::new(File::open(args.get(1).expect("No operations file given"))?);
-
-    let audio_in: Result<Box<dyn Read>, io::Error> = args.get(2).map_or(
-        Ok(Box::new(io::stdin())),
-        |name| Ok(Box::new(File::open(name)?)));
-
-    let audio_out: Result<Box<dyn Write>, io::Error> = args.get(3).map_or(
-        Ok(Box::new(io::stdout())),
-        |name| Ok(Box::new(File::create(name)?)));
-
-    if audio_in.is_err() {
-        return Err(audio_in.err().unwrap());
-    }
-
-    if audio_out.is_err() {
-        return Err(audio_out.err().unwrap());
-    }
-
-    Ok((operations, audio_in.unwrap(), audio_out.unwrap()))
-}
-
-fn read_ops(file: &mut dyn Read) -> Result<OpSequence, io::Error> {
+fn read_ops(file_name: &str) -> Result<OpSequence, io::Error> {
     let mut text = String::new();
     let mut op_sequence = OpSequence::new();
+    let mut file = File::open(file_name)?;
     file.read_to_string(&mut text)?;
     for line in text.lines() {
         let (start, duration, op) = boucle::ops::new_from_string(line).expect("Failed to parse line");
@@ -45,19 +24,28 @@ fn read_ops(file: &mut dyn Read) -> Result<OpSequence, io::Error> {
 }
 
 fn main() {
-    println!("Boucle looper");
+    let matches = App::new("Boucle looper")
+        .version("1.0")
+        .arg(Arg::with_name("INPUT")
+             .required(true)
+             .index(1))
+        .arg(Arg::with_name("OUTPUT")
+             .required(true)
+             .index(2))
+        .get_matches();
 
-    let args: Vec<String> = env::args().collect();
+    let audio_in = matches.value_of("INPUT").unwrap();
+    let audio_out = matches.value_of("OUTPUT").unwrap();
 
-    let (mut operations_file, audio_in, _audio_out) = parse_args(&args).expect("Failed to open args");
+    let operations_file = "ops.test";
 
-    let op_sequence = read_ops(&mut operations_file).expect("Failed to read ops");
+    let op_sequence = read_ops(&operations_file).expect("Failed to read ops");
     for op in &op_sequence {
         println!("{}", op);
     }
 
     println!("Reading input...");
-    let mut reader = hound::WavReader::new(io::BufReader::new(audio_in)).unwrap(); //expect("Failed to read input");
+    let mut reader = hound::WavReader::open(audio_in).unwrap(); //expect("Failed to read input");
     let spec = reader.spec();
 
     if spec.channels != 1 {
@@ -66,7 +54,7 @@ fn main() {
 
     let buffer: Vec<Sample> = reader.samples::<Sample>().map(|s| s.unwrap()).collect();
 
-    let mut writer = hound::WavWriter::create("output.wav", spec).unwrap();
+    let mut writer = hound::WavWriter::create(audio_out, spec).unwrap();
 
     let boucle: boucle::Boucle = boucle::Boucle::new(boucle::Config::default());
     boucle.process_buffer(&buffer, &op_sequence, &mut |s| writer.write_sample(s).unwrap());


### PR DESCRIPTION
And remove default-to-stdin behaviour - difficult to implement
and not useful.